### PR TITLE
Fix another bug in get_channel_name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-retro",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Keep track of hubot comments",
   "main": "index.coffee",
   "author": {

--- a/src/retro.coffee
+++ b/src/retro.coffee
@@ -75,8 +75,11 @@ get_items_string = (items) ->
   "#{item.user}:#{item.message} #{if item.channel then '' else '(channel unknown)'}" for item in items
 
 get_channel_name = (response, robot) ->
-  channel_id = get_channel_id(response)
-  robot.adapter.client.rtm.dataStore.getChannelById(channel_id).name
+  channel_id = response.message.room
+  if channel_id == response.message.user.name
+    channel_id
+  else
+    robot.adapter.client.rtm.dataStore.getChannelById(channel_id).name
 
 get_channel_id = (response) ->
   if response.message.room == response.message.user.name


### PR DESCRIPTION
This time it was trying to look up channel names based on channel ids prefixed with hash marks.